### PR TITLE
feat: Add /jp page for rewrite from nextjs-app-global

### DIFF
--- a/app/jp/page.tsx
+++ b/app/jp/page.tsx
@@ -1,0 +1,9 @@
+export default function JpPage() {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>日本版ページへようこそ</h1>
+      <p>このページは nextjs-app-global から rewrite で呼び出されています。</p>
+      <p>JP_DOMAIN: {process.env.JP_DOMAIN || 'localhost:3001'}</p>
+    </div>
+  );
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,19 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: '/jp/:path*',
+        headers: [
+          {
+            key: 'X-JP-App',
+            value: 'true',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev --turbopack -p 3001",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
- Create /jp page component to handle rewrites
- Configure headers to identify JP app requests
- Set development server port to 3001

🤖 Generated with [Claude Code](https://claude.ai/code)